### PR TITLE
Autocompleter fix

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -189,27 +189,26 @@
 				});
 						
 				if (settings.autocomplete_url != undefined) {
-				  autocomplete_options = {source: settings.autocomplete_url};
-				  for (attrname in settings.autocomplete) { 
-				    autocomplete_options[attrname] = settings.autocomplete[attrname]; 
-				  }
+					autocomplete_options = {source: settings.autocomplete_url};
+					for (attrname in settings.autocomplete) { 
+						autocomplete_options[attrname] = settings.autocomplete[attrname]; 
+					}
 				  
-				  if (jQuery.Autocompleter !== undefined) {
-				    $(data.fake_input).autocomplete(settings.autocomplete_url, settings.autocomplete);
-				    $(data.fake_input).bind('result',data,function(event,data,formatted) {
-              if (data) {
-                d = data + "";
-                $(event.data.real_input).addTag(d,{focus:true,unique:(settings.unique)});
-              }
-            });
-				  } else if (jQuery.ui.autocomplete !== undefined) {
-					  $(data.fake_input).autocomplete(autocomplete_options);
-					  $(data.fake_input).bind('autocompleteselect',data,function(event,ui) {
-  					  $(event.data.real_input).addTag(ui.item.value,{focus:true,unique:(settings.unique)});
-  					  return false;
-            });
-				  }
-					
+					if (jQuery.Autocompleter !== undefined) {
+						$(data.fake_input).autocomplete(settings.autocomplete_url, settings.autocomplete);
+						$(data.fake_input).bind('result',data,function(event,data,formatted) {
+							if (data) {
+								d = data[0] + "";
+								$(event.data.real_input).addTag(d,{focus:true,unique:(settings.unique)});
+							}
+						});
+					} else if (jQuery.ui.autocomplete !== undefined) {
+						$(data.fake_input).autocomplete(autocomplete_options);
+						$(data.fake_input).bind('autocompleteselect',data,function(event,ui) {
+							$(event.data.real_input).addTag(ui.item.value,{focus:true,unique:(settings.unique)});
+							return false;
+						});
+					}
 					
 				} else {
 						// if a user tabs out of the field, create a new tag


### PR DESCRIPTION
Fixed Autocompleter select, it generated a tag erroneously `apple,apple` instead of just `apple` when selected from the autocomplete menu. See: http://d.pr/YLj8

Also used tabs for indenting since it had tabs and spaces mixed.
