### PR TITLE
Support for [brackets] in ids

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -61,7 +61,7 @@
             letterSpacing: input.css('letterSpacing'),
             whiteSpace: 'nowrap'
         }),
-        testerId = $(this).attr('id')+'_autosize_tester';
+        testerId = $.fn.tagsInput.formattedId($(this)) + '_autosize_tester';
     if(! $('#'+testerId).length > 0){
       testSubject.attr('id', testerId);
       testSubject.appendTo('body');
@@ -76,7 +76,7 @@
 	$.fn.addTag = function(value,options) {
 			options = jQuery.extend({focus:false,callback:true},options);
 			this.each(function() { 
-				var id = $(this).attr('id');
+				var id = $.fn.tagsInput.formattedId($(this));
 
 				var tagslist = $(this).val().split(delimiter[id]);
 				if (tagslist[0] == '') { 
@@ -138,7 +138,7 @@
 	$.fn.removeTag = function(value) { 
 			value = unescape(value);
 			this.each(function() { 
-				var id = $(this).attr('id');
+				var id = $.fn.tagsInput.formattedId($(this));
 	
 				var old = $(this).val().split(delimiter[id]);
 					
@@ -167,7 +167,7 @@
 	
 	// clear all existing tags and import new ones from a string
 	$.fn.importTags = function(str) {
-                id = $(this).attr('id');
+                id = $.fn.tagsInput.formattedId($(this));
 		$('#'+id+'_tagsinput .tag').remove();
 		$.fn.tagsInput.importTags(this,str);
 	}
@@ -194,9 +194,9 @@
 			if (settings.hide) { 
 				$(this).hide();				
 			}
-				
-			var id = $(this).attr('id')
 			
+			var id = $.fn.tagsInput.formattedId($(this));
+									
 			var data = jQuery.extend({
 				pid:id,
 				real_input: '#'+id,
@@ -214,10 +214,12 @@
 				tags_callbacks[id]['onChange'] = settings.onChange;
 			}
 	
-			var markup = '<div id="'+id+'_tagsinput" class="tagsinput"><div id="'+id+'_addTag">';
+			var unescapedId = id.replace(/\\/g,"");
+	
+			var markup = '<div id="'+ unescapedId +'_tagsinput" class="tagsinput"><div id="'+ unescapedId +'_addTag">';
 			
 			if (settings.interactive) {
-				markup = markup + '<input id="'+id+'_tag" value="" data-default="'+settings.defaultText+'" />';
+				markup = markup + '<input id="'+ unescapedId +'_tag" value="" data-default="'+settings.defaultText+'" />';
 			}
 			
 			markup = markup + '</div><div class="tags_clear"></div></div>';
@@ -304,7 +306,7 @@
 					{
 						 event.preventDefault();
 						 var last_tag = $(this).closest('.tagsinput').find('.tag:last').text();
-						 var id = $(this).attr('id').replace(/_tag$/, '');
+						 var id = $.fn.tagsInput.formattedId($(this)).replace(/_tag$/, '');
 						 last_tag = last_tag.replace(/[\s]+x$/, '');
 						 $('#' + id).removeTag(escape(last_tag));
 						 $(this).trigger('focus');
@@ -329,13 +331,13 @@
 	};
 	
 	$.fn.tagsInput.updateTagsField = function(obj,tagslist) { 
-		var id = $(obj).attr('id');
+		var id = $.fn.tagsInput.formattedId($(obj));
 		$(obj).val(tagslist.join(delimiter[id]));
 	};
 	
 	$.fn.tagsInput.importTags = function(obj,val) {			
 		$(obj).val('');
-		var id = $(obj).attr('id');
+		var id = $.fn.tagsInput.formattedId($(obj));
 		var tags = val.split(delimiter[id]);
 		for (i=0; i<tags.length; i++) { 
 			$(obj).addTag(tags[i],{focus:false,callback:false});
@@ -345,6 +347,12 @@
 			var f = tags_callbacks[id]['onChange'];
 			f.call(obj, obj, tags[i]);
 		}
+	};
+	
+	$.fn.tagsInput.formattedId = function(obj) {
+		var id = obj.attr('id')
+		if(id === undefined) return id; 
+		return id.replace(/\[/g,"\\[").replace(/\]/g,"\\]");
 	};
 
 })(jQuery);


### PR DESCRIPTION
Hi,

I'm using ids like something[withabracket][maybeanotherbracket]

In order to select these with jQuery you need to escape the brackets. 

I.e. $("#something\\[withabracket\\]\\[maybeanotherbracket\\]")

I've made a simple fix for this, not sure how elegant it is, but might be useful for others too? I'm happy to tweak the solution if you've got any ideas on how to do it better.

Cheers,
Erling

