### PR TITLE
Fix tag deletion with backspace for IE8

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -310,7 +310,7 @@
 						 event.preventDefault();
 						 var last_tag = $(this).closest('.tagsinput').find('.tag:last').text();
 						 var id = $(this).attr('id').replace(/_tag$/, '');
-						 last_tag = last_tag.replace(/[\s]+x$/, '');
+						 last_tag = last_tag.replace(/[\s\u00a0]+x$/, '');
 						 $('#' + id).removeTag(escape(last_tag));
 						 $(this).trigger('focus');
 					}


### PR DESCRIPTION
Deleting tags with backspace in IE8 doesn't work due to nbsp not being a part of the \s class there.