### PR TITLE
Add placeholder option

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -187,6 +187,7 @@
       'unique':true,
       removeWithBackspace:true,
       placeholderColor:'#666666',
+      placeholder: '',
       autosize: true,
       comfortZone: 20,
       inputPadding: 6*2
@@ -221,7 +222,14 @@
 			var markup = '<div id="'+id+'_tagsinput" class="tagsinput"><div id="'+id+'_addTag">';
 			
 			if (settings.interactive) {
-				markup = markup + '<input id="'+id+'_tag" value="" data-default="'+settings.defaultText+'" />';
+        if(settings.placeholder != '')
+        {
+          markup = markup + '<input id="'+id+'_tag" value="" placeholder="'+settings.placeholder+'" />';
+        }
+        else
+        {
+          markup = markup + '<input id="'+id+'_tag" value="" data-default="'+settings.defaultText+'" />';
+        }
 			}
 			
 			markup = markup + '</div><div class="tags_clear"></div></div>';


### PR DESCRIPTION
Ok so this is a pretty terrible implementation but I just threw something together so you can now have the option of using a placeholder text instead of the javascript default text. It shouldn't mess with anyone that still wants to use the defaultText option. See ticket https://github.com/xoxco/jQuery-Tags-Input/issues/62

I forgot to add the ticket # in my commit :)