### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "xoxco/jquery-tags-input",
+    "description": "Magically convert a simple text input into a cool tag list with this jQuery plugin.",
+    "type": "component",
+    "homepage": "http://xoxco.com/projects/code/tagsinput/",
+    "license": "MIT",
+    "support": {
+        "issues": "https://github.com/xoxco/jQuery-Tags-Input/issues"
+    },
+    "authors": [
+        {
+            "name": "Ben Brown",
+            "homepage": "http://benbrown.com"
+        }
+    ],
+    "require": {
+        "components/jquery": "*"
+    },
+    "extra": {
+        "component": {
+            "scripts": [
+                "jquery.tagsinput.js"
+            ],
+            "styles": [
+                "jquery.tagsinput.css"
+            ],
+            "shim": {
+                "deps": "jquery"
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
             "styles": [
                 "jquery.tagsinput.css"
             ],
+            "files": [
+                "jquery.tagsinput.min.js"
+            ],
             "shim": {
                 "deps": "jquery"
             }


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a package management system for PHP. This pull request allows PHP projects to depend on, download and install jQuery Tags Input. Once available, you could stick `xoxco/jquery-tags-input` in your own *composer.json* file, run `composer.phar install` and have jQuery Tags Input be downloaded for you.

Thank you, and great work with this jQuery plugin. It's great!