### PR TITLE
Adding extra class option to tagsinput wrapper div

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -189,7 +189,8 @@
       placeholderColor:'#666666',
       autosize: true,
       comfortZone: 20,
-      inputPadding: 6*2
+      inputPadding: 6*2,
+      extraClass: null
     },options);
 
 		this.each(function() { 
@@ -218,7 +219,7 @@
 				tags_callbacks[id]['onChange'] = settings.onChange;
 			}
 	
-			var markup = '<div id="'+id+'_tagsinput" class="tagsinput"><div id="'+id+'_addTag">';
+			var markup = '<div id="'+id+'_tagsinput" class="tagsinput '+settings.extraClass+'"><div id="'+id+'_addTag">';
 			
 			if (settings.interactive) {
 				markup = markup + '<input id="'+id+'_tag" value="" data-default="'+settings.defaultText+'" />';


### PR DESCRIPTION
If you have multiple and an unknown number of tagsinput instances on a page you cannot use IDs to style them. This commit adds extraClass as an option for a user to specify a class name.

In our case, this has come in useful when we have the tagsinput on two different element types on our page. We initialise it once with one extraClass and again with a different extraClass, enabling us to have control of positional style differences between the two input fields.