### PR TITLE
Avoid onChange being fire before user change the input

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -210,14 +210,7 @@
 			},settings);
 	
 			delimiter[id] = data.delimiter;
-			
-			if (settings.onAddTag || settings.onRemoveTag || settings.onChange) {
-				tags_callbacks[id] = new Array();
-				tags_callbacks[id]['onAddTag'] = settings.onAddTag;
-				tags_callbacks[id]['onRemoveTag'] = settings.onRemoveTag;
-				tags_callbacks[id]['onChange'] = settings.onChange;
-			}
-	
+				
 			var markup = '<div id="'+id+'_tagsinput" class="tagsinput"><div id="'+id+'_addTag">';
 			
 			if (settings.interactive) {
@@ -326,6 +319,14 @@
 				    });
 				}
 			} // if settings.interactive
+			
+			if (settings.onAddTag || settings.onRemoveTag || settings.onChange) {
+				tags_callbacks[id] = new Array();
+				tags_callbacks[id]['onAddTag'] = settings.onAddTag;
+				tags_callbacks[id]['onRemoveTag'] = settings.onRemoveTag;
+				tags_callbacks[id]['onChange'] = settings.onChange;
+			}
+
 		});
 			
 		return this;


### PR DESCRIPTION
Currently, the onChange is fired as soon as the tagsinput is initialised, which is non ideal because there is no changes actually made. This can be harmful incase user want to implement auto submit. This patch correct such behaviour.