### PR TITLE
Added support for removing tags one at a time with backspace

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -186,6 +186,7 @@
       'delimiter':',',
       'unique':true,
       removeWithBackspace:true,
+      removeSingle: false,
       placeholderColor:'#666666',
       autosize: true,
       comfortZone: 20,
@@ -208,6 +209,8 @@
 				input_wrapper: '#'+id+'_addTag',
 				fake_input: '#'+id+'_tag'
 			},settings);
+
+			var canRemoveTag = true;
 	
 			delimiter[id] = data.delimiter;
 			
@@ -302,17 +305,28 @@
             
           			}
 				});
-				//Delete last tag on backspace
-				data.removeWithBackspace && $(data.fake_input).bind('keydown', function(event)
+				data.removeSingle && data.removeWithBackspace && $(data.fake_input).bind('keyup', function(event)
 				{
 					if(event.keyCode == 8 && $(this).val() == '')
 					{
-						 event.preventDefault();
-						 var last_tag = $(this).closest('.tagsinput').find('.tag:last').text();
-						 var id = $(this).attr('id').replace(/_tag$/, '');
-						 last_tag = last_tag.replace(/[\s]+x$/, '');
-						 $('#' + id).removeTag(escape(last_tag));
-						 $(this).trigger('focus');
+						canRemoveTag = true;
+					}
+				});
+				//Delete last tag on backspace
+				data.removeWithBackspace && $(data.fake_input).bind('keydown', function(event)
+				{
+					if(event.keyCode == 8 && canRemoveTag)
+					{
+						if($(this).val() == '')
+						{
+							event.preventDefault();
+						 	var last_tag = $(this).closest('.tagsinput').find('.tag:last').text();
+						 	var id = $(this).attr('id').replace(/_tag$/, '');
+						 	last_tag = last_tag.replace(/[\s]+X$/, '');
+						 	$('#' + id).removeTag(escape(last_tag));
+						 	$(this).trigger('focus');	
+						}
+						canRemoveTag = !data.removeSingle;
 					}
 				});
 				$(data.fake_input).blur();


### PR DESCRIPTION
Hi, I have added a small flag called "removeSingle" in the settings. This feature, if enabled (by default disabled), will make it impossible to remove multiple tags while holding backspace (given that removeWithBackspace is true). To remove tags with backspace, the user will have to press backspace and the next tag will only be removed if the button is released and then pressed again. This way the plugin omits cases where the user presses and holds backspace and by mistake removes more tags then intended.

Keep up the good work

Vaclav