### PR TITLE
Added beforeAddTag callback

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -94,8 +94,14 @@
 				} else {
 					var skipTag = false; 
 				}
-				
-				if (value !='' && skipTag != true) { 
+
+        if (options.callback && tags_callbacks[id] && tags_callbacks[id]['beforeAddTag']) {
+          var f = tags_callbacks[id]['beforeAddTag'];
+          var canBeAdded = f.call(this, $('#'+id+'_tag'));
+          if(!canBeAdded) return;
+        }
+
+				if (value !='' && skipTag != true) {
                     $('<span>').addClass('tag').append(
                         $('<span>').text(value).append('&nbsp;&nbsp;'),
                         $('<a>', {
@@ -117,7 +123,9 @@
 					}
 					
 					$.fn.tagsInput.updateTagsField(this,tagslist);
-					
+
+					$.fn.tagsInput.updateTagsField(this,tagslist);
+
 					if (options.callback && tags_callbacks[id] && tags_callbacks[id]['onAddTag']) {
 						var f = tags_callbacks[id]['onAddTag'];
 						f.call(this, value);
@@ -210,12 +218,13 @@
 			},settings);
 	
 			delimiter[id] = data.delimiter;
-			
-			if (settings.onAddTag || settings.onRemoveTag || settings.onChange) {
+
+			if (settings.onAddTag || settings.onRemoveTag || settings.onChange || settings.beforeAddTag) {
 				tags_callbacks[id] = new Array();
 				tags_callbacks[id]['onAddTag'] = settings.onAddTag;
 				tags_callbacks[id]['onRemoveTag'] = settings.onRemoveTag;
 				tags_callbacks[id]['onChange'] = settings.onChange;
+				tags_callbacks[id]['beforeAddTag'] = settings.beforeAddTag;
 			}
 	
 			var markup = '<div id="'+id+'_tagsinput" class="tagsinput"><div id="'+id+'_addTag">';


### PR DESCRIPTION
This callback can be used for validating format of input/ any other actions to be done before adding tag.

Example: 
inputElement.tagsInput({width: '100%', height: '20px, beforeAddTag: validateEmailAddress})

function validateEmailAddress(tag){
    var emailRegex = /^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/;
    if(!tag.val().match(emailRegex)){
      tag.addClass("not_valid");
      return false;
    }else{
      return true;
    }
  }
