### PR TITLE
Fix datetime function for generating IDs

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -13,6 +13,7 @@
 	ben@xoxco.com
 
 */
+var count = 0;
 
 (function($) {
 
@@ -192,13 +193,14 @@
       inputPadding: 6*2
     },options);
 
-		this.each(function() { 
+		this.each(function() {
+			count++;
 			if (settings.hide) { 
 				$(this).hide();				
 			}
 			var id = $(this).attr('id');
 			if (!id || delimiter[$(this).attr('id')]) {
-				id = $(this).attr('id', 'tags' + new Date().getTime()).attr('id');
+				id = $(this).attr('id', 'tags' + count).attr('id');
 			}
 			
 			var data = jQuery.extend({


### PR DESCRIPTION
Running into ID collision using the gettime() method for trying to generate unique IDs on an Intel I7. Instead why not just use a counter to ensure all the IDs are unique?