### PR TITLE
Added a 'RemoveAllTags' func to be cleaner

### DIFF
--- a/jquery.tagsinput.js
+++ b/jquery.tagsinput.js
@@ -160,6 +160,11 @@
 					
 			return false;
 		};
+	$.fn.removeAllTags = function() {
+                id = $(this).attr('id');
+                $(this).val('');
+		$('#'+id+'_tagsinput .tag').remove();
+	}
 	
 	$.fn.tagExist = function(val) {
 		var id = $(this).attr('id');


### PR DESCRIPTION
From now, you don't need to call importTags('') anymore to flush all the tag, you can simply call removeAllTags()