### PR TITLE
fixed duplicating id

### DIFF
--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -192,13 +192,15 @@
       inputPadding: 6*2
     },options);
 
+    	var uniqueIdCounter = 0;
+
 		this.each(function() {
 			if (settings.hide) {
 				$(this).hide();
 			}
 			var id = $(this).attr('id');
 			if (!id || delimiter[$(this).attr('id')]) {
-				id = $(this).attr('id', 'tags' + new Date().getTime()).attr('id');
+				id = $(this).attr('id', 'tags' + new Date().getTime() + (uniqueIdCounter++)).attr('id');
 			}
 
 			var data = jQuery.extend({


### PR DESCRIPTION
"new Date().getTime()" sometimes gives same value for more than 1 container so selecting container by class can be buggy