### PR TITLE
Allow custom autocomplete renderItem

### DIFF
--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -266,6 +266,9 @@
 					  	});
 					} else if (jQuery.ui.autocomplete !== undefined) {
 						$(data.fake_input).autocomplete(autocomplete_options);
+						if(settings.autocomplete_renderitem) {
+							$(data.fake_input).data('ui-autocomplete')._renderItem = settings.autocomplete_renderitem;
+						}
 						$(data.fake_input).bind('autocompleteselect',data,function(event,ui) {
 							$(event.data.real_input).addTag(ui.item.value,{focus:true,unique:(settings.unique)});
 							return false;


### PR DESCRIPTION
Allows users to pass through a custom renderItem function to be used for the tag autocompletes, using the autocomplete_renderitem config option. See http://api.jqueryui.com/autocomplete/#method-_renderItem
