### PR TITLE
More input emulation and modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ option to false.
 	$(selector).tagsInput({
 	   'autocomplete_url': url_to_autocomplete_api,
 	   'autocomplete': { option: value, option: value},
-	   'height':'100px',
-	   'width':'300px',
 	   'interactive':true,
 	   'defaultText':'add a tag',
 	   'onAddTag':callback_function,
@@ -98,6 +96,5 @@ option to false.
 	   'delimiter': [',',';'],   // Or a string with a single delimiter. Ex: ';'
 	   'removeWithBackspace' : true,
 	   'minChars' : 0,
-	   'maxChars' : 0, // if not provided there is no limit
-	   'placeholderColor' : '#666666'
+	   'maxChars' : 0 // if not provided there is no limit
 	});

--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -97,10 +97,10 @@
 
 				if (value !='' && skipTag != true) {
                     $('<span>').addClass('tag').append(
-                        $('<span>').text(value).append('&nbsp;&nbsp;'),
+                        $('<span>').text(value),
                         $('<a>', {
                             href  : '#',
-                            title : 'Removing tag',
+                            title : 'Remove tag',
                             text  : '×',
                             tabindex : '-1'
                         }).click(function () {
@@ -178,7 +178,7 @@
 	$.fn.tagsInput = function(options) {
     var settings = jQuery.extend({
       interactive:true,
-      defaultText:'add a tag',
+      defaultText:'Add tags',
       minChars:0,
       autocomplete: {selectFirst: false },
       hide:true,

--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -101,7 +101,8 @@
                         $('<a>', {
                             href  : '#',
                             title : 'Removing tag',
-                            text  : '×'
+                            text  : '×',
+                            tabindex : '-1'
                         }).click(function () {
                             return $('#' + id).removeTag(escape(value));
                         })
@@ -239,7 +240,11 @@
 				$.fn.tagsInput.importTags($(data.real_input),$(data.real_input).val());
 			}
 			if (settings.interactive) {
-				$(data.fake_input).attr("placeholder",$(data.fake_input).attr('data-default'));
+				$(data.fake_input).attr("placeholder",$(data.fake_input).attr('data-default')).blur(function() {
+					$(this).parents(".tagsinput").removeClass("focus");
+				}).focus(function() {
+					$(this).parents(".tagsinput").addClass("focus");
+				});
 		        $(data.fake_input).resetAutosize(settings);
 
 				if (settings.autocomplete_url != undefined) {

--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -101,7 +101,7 @@
                         $('<a>', {
                             href  : '#',
                             title : 'Removing tag',
-                            text  : 'x'
+                            text  : '×'
                         }).click(function () {
                             return $('#' + id).removeTag(escape(value));
                         })
@@ -179,14 +179,11 @@
       interactive:true,
       defaultText:'add a tag',
       minChars:0,
-      width:'300px',
-      height:'100px',
       autocomplete: {selectFirst: false },
       hide:true,
       delimiter: ',',
       unique:true,
       removeWithBackspace:true,
-      placeholderColor:'#666666',
       autosize: true,
       comfortZone: 20,
       inputPadding: 6*2
@@ -238,28 +235,12 @@
 
 			$(markup).insertAfter(this);
 
-			$(data.holder).css('width',settings.width);
-			$(data.holder).css('min-height',settings.height);
-			$(data.holder).css('height',settings.height);
-
 			if ($(data.real_input).val()!='') {
 				$.fn.tagsInput.importTags($(data.real_input),$(data.real_input).val());
 			}
 			if (settings.interactive) {
-				$(data.fake_input).val($(data.fake_input).attr('data-default'));
-				$(data.fake_input).css('color',settings.placeholderColor);
+				$(data.fake_input).attr("placeholder",$(data.fake_input).attr('data-default'));
 		        $(data.fake_input).resetAutosize(settings);
-
-				$(data.holder).bind('click',data,function(event) {
-					$(event.data.fake_input).focus();
-				});
-
-				$(data.fake_input).bind('focus',data,function(event) {
-					if ($(event.data.fake_input).val()==$(event.data.fake_input).attr('data-default')) {
-						$(event.data.fake_input).val('');
-					}
-					$(event.data.fake_input).css('color','#000000');
-				});
 
 				if (settings.autocomplete_url != undefined) {
 					autocomplete_options = {source: settings.autocomplete_url};
@@ -282,7 +263,6 @@
 						});
 					}
 
-
 				} else {
 						// if a user tabs out of the field, create a new tag
 						// this is only available if autocomplete is not used.
@@ -292,8 +272,7 @@
 								if( (event.data.minChars <= $(event.data.fake_input).val().length) && (!event.data.maxChars || (event.data.maxChars >= $(event.data.fake_input).val().length)) )
 									$(event.data.real_input).addTag($(event.data.fake_input).val(),{focus:true,unique:(settings.unique)});
 							} else {
-								$(event.data.fake_input).val($(event.data.fake_input).attr('data-default'));
-								$(event.data.fake_input).css('color',settings.placeholderColor);
+								$(event.data.fake_input).val('');
 							}
 							return false;
 						});
@@ -320,7 +299,7 @@
 						 event.preventDefault();
 						 var last_tag = $(this).closest('.tagsinput').find('.tag:last').text();
 						 var id = $(this).attr('id').replace(/_tag$/, '');
-						 last_tag = last_tag.replace(/[\s]+x$/, '');
+						 last_tag = last_tag.replace(/[\s]+×$/, '');
 						 $('#' + id).removeTag(escape(last_tag));
 						 $(this).trigger('focus');
 					}

--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -307,7 +307,7 @@
 						 event.preventDefault();
 						 var last_tag = $(this).closest('.tagsinput').find('.tag:last').text();
 						 var id = $(this).attr('id').replace(/_tag$/, '');
-						 last_tag = last_tag.replace(/[\s]+×$/, '');
+						 last_tag = last_tag.replace(/×$/, '');
 						 $('#' + id).removeTag(escape(last_tag));
 						 $(this).trigger('focus');
 					}

--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -234,7 +234,10 @@
 
 			markup = markup + '</div><div class="tags_clear"></div></div>';
 
-			$(markup).insertAfter(this);
+			$(markup).insertAfter(this).on("click mousedown", function(e) {
+				$(data.fake_input).focus();
+				e.preventDefault();
+			});
 
 			if ($(data.real_input).val()!='') {
 				$.fn.tagsInput.importTags($(data.real_input),$(data.real_input).val());


### PR DESCRIPTION
Uses the HTML5 `placeholder` attribute.
Makes the entire thing feel more like a real input (click anywhere to focus the fake input, add `focus` class on parent).
No fixed width and height.
