### PR TITLE
Update path to main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jQuery-Tags-Input",
   "version": "1.3.5",
   "description": "",
-  "main": "jquery.tagsinput.js",
+  "main": "src/jquery.tagsinput.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
I got an error trying to run `require('jquery-tags-input')`. I was trying to use npm distribution of the module via browserify.

It can by fixed by changing the path to the main file.
