### PR TITLE
Fix bug: Unquoted backspace in regular expression

### DIFF
--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -330,7 +330,7 @@
 				//Removes the not_valid class when user changes the value of the fake input
 				if(data.unique) {
 				    $(data.fake_input).keydown(function(event){
-				        if(event.keyCode == 8 || String.fromCharCode(event.which).match(/\w+|[áéíóúÁÉÍÓÚñÑ,/]+/)) {
+				        if(event.keyCode == 8 || String.fromCharCode(event.which).match(/\w+|[áéíóúÁÉÍÓÚñÑ,\/]+/)) {
 				            $(this).removeClass('not_valid');
 				        }
 				    });


### PR DESCRIPTION
This causes an error in when trying to minify the code with some minifiers, e.g. Perl module JavaScript::Minifier.
