### PR TITLE
When the tags are changed for a field, trigger the change event

### DIFF
--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -345,6 +345,7 @@
 	$.fn.tagsInput.updateTagsField = function(obj,tagslist) {
 		var id = $(obj).attr('id');
 		$(obj).val(tagslist.join(delimiter[id]));
+		$(obj).trigger('change');
 	};
 
 	$.fn.tagsInput.importTags = function(obj,val) {


### PR DESCRIPTION
Allows users to create custom events when tags are added. For example, if there is a max length for a tags field, it can check whether the user has gone over.
