### PR TITLE
updated readme documentation to include 'unique' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,6 @@ option to false.
 	   'removeWithBackspace' : true,
 	   'minChars' : 0,
 	   'maxChars' : 0, // if not provided there is no limit
-	   'placeholderColor' : '#666666'
+	   'placeholderColor' : '#666666',
+	   'unique' : true // set to false if you want to allow duplicate tags
 	});


### PR DESCRIPTION
I was looking for a way to allow dupe tags, and noticed that there is a "unique" option that wasn't documented in the readme example, so I just updated the readme. This pull request includes no code changes.
