### PR TITLE
Change the delete link to a multiplication sign '×'

### DIFF
--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -101,7 +101,7 @@
                         $('<a>', {
                             href  : '#',
                             title : 'Removing tag',
-                            text  : 'x'
+                            text  : '×'
                         }).click(function () {
                             return $('#' + id).removeTag(escape(value));
                         })


### PR DESCRIPTION
Small detail: the '×' gives a cleaner look as delete character than a standard 'x'.
