### PR TITLE
Fix: Hide autocomplete ui on tag completion by key stroke

### DIFF
--- a/src/jquery.tagsinput.js
+++ b/src/jquery.tagsinput.js
@@ -306,6 +306,7 @@
 						if( (event.data.minChars <= $(event.data.fake_input).val().length) && (!event.data.maxChars || (event.data.maxChars >= $(event.data.fake_input).val().length)) )
 							$(event.data.real_input).addTag($(event.data.fake_input).val(),{focus:true,unique:(settings.unique)});
 					  	$(event.data.fake_input).resetAutosize(settings);
+					        $(this).autocomplete("close");
 						return false;
 					} else if (event.data.autosize) {
 			            $(event.data.fake_input).doAutosize(settings);


### PR DESCRIPTION
The autocomplete UI is not getting dismissed when a tag is complete by key stroke.  